### PR TITLE
Add support for sending HTTP 405 - Method Not Allowed.

### DIFF
--- a/include/pistache/http.h
+++ b/include/pistache/http.h
@@ -487,6 +487,12 @@ public:
      * - movedPermantly -> 301
      * - moved() -> 302
      */
+    Async::Promise<ssize_t> sendMethodNotAllowed(const std::vector<Http::Method>& supportedMethods) {
+        code_ = Http::Code::Method_Not_Allowed;
+        headers_.add(std::shared_ptr<Http::Header::Header>(new Header::Allow(supportedMethods)));
+        std::string body = "Method Not Allowed";
+        return putOnWire(body.c_str(), body.size());
+    }
 
     Async::Promise<ssize_t> send(Code code) {
         code_ = code;

--- a/include/pistache/http.h
+++ b/include/pistache/http.h
@@ -489,8 +489,8 @@ public:
      */
     Async::Promise<ssize_t> sendMethodNotAllowed(const std::vector<Http::Method>& supportedMethods) {
         code_ = Http::Code::Method_Not_Allowed;
-        headers_.add(std::shared_ptr<Http::Header::Header>(new Header::Allow(supportedMethods)));
-        std::string body = "Method Not Allowed";
+        headers_.add(std::make_shared<Http::Header::Allow>(supportedMethods));
+        std::string body = codeString(Pistache::Http::Code::Method_Not_Allowed);
         return putOnWire(body.c_str(), body.size());
     }
 

--- a/include/pistache/router.h
+++ b/include/pistache/router.h
@@ -70,7 +70,7 @@ class Request;
 struct Route {
     enum class Result { Ok, Failure };
 
-    enum class Status { Match, NotFound };
+    enum class Status { Match, NotFound, NotAllowed };
 
     typedef std::function<Result(const Request, Http::ResponseWriter)> Handler;
 

--- a/src/server/router.cc
+++ b/src/server/router.cc
@@ -441,9 +441,13 @@ Router::route(const Http::Request& req, Http::ResponseWriter response) {
         if (handler1 == Route::Result::Ok) return Route::Status::Match;
     }
 
-    //No route or custom handler found. Let's walk through the list of other methods and see if any of them support
-    // this resource. This will allow server to send a HTTP 405 (method not allowed) response.
-    //RFC requires HTTP 405 responses to include a list of supported methods for the requested resource.
+    //No route or custom handler found. Let's walk through the
+    // list of other methods and see if any of them support
+    // this resource.
+    //This will allow server to send a
+    // HTTP 405 (method not allowed) response.
+    //RFC 7231 requires HTTP 405 responses to include a list of
+    // supported methods for the requested resource.
     std::vector<Http::Method> supportedMethods;
     for (auto& methods: routes) {
         if (methods.first == req.method()) continue;
@@ -461,9 +465,9 @@ Router::route(const Http::Request& req, Http::ResponseWriter response) {
     }
 
     if (hasNotFoundHandler()) {
-        invokeNotFoundHandler(req, std::move(response));
+      invokeNotFoundHandler(req, std::move(response));
     } else {
-        response.send(Http::Code::Not_Found, "Could not find a matching route");
+      response.send(Http::Code::Not_Found, "Could not find a matching route");
     }
     return Route::Status::NotFound;
 }

--- a/tests/rest_server_test.cc
+++ b/tests/rest_server_test.cc
@@ -81,3 +81,41 @@ TEST(rest_server_test, basic_test) {
 
     stats.shutdown();
 }
+
+TEST(rest_server_test, response_status_code_test) {
+    int thr = 1;
+
+    Address addr(Ipv4::any(), Port(0));
+
+    StatsEndpoint stats(addr);
+
+    stats.init(thr);
+    stats.start();
+    Port port = stats.getPort();
+
+    cout << "Cores = " << hardware_concurrency() << endl;
+    cout << "Using " << thr << " threads" << endl;
+    cout << "Port = " << port << endl;
+
+    httplib::Client client("localhost", port);
+
+    //Code 404 - Not Found.
+    auto res = client.Get("/read/does_not_exist");
+    EXPECT_EQ(res->status, 404);
+    EXPECT_EQ(res->body, "Could not find a matching route");
+
+    //Code 405 - Method Not Allowed.
+    std::string body("body goes here");
+    res = client.Post("/read/function1", body, "text/plain");
+    EXPECT_EQ(res->status, 405);
+    EXPECT_EQ(res->body, "Method Not Allowed");
+    ASSERT_TRUE(res->has_header("Allow"));
+    EXPECT_EQ(res->get_header_value("Allow"), "GET");
+
+    //Code 415 - Unknown Media Type
+    res = client.Post("/read/function1", body, "invalid");
+    EXPECT_EQ(res->status, 415);
+    EXPECT_EQ(res->body, "Unknown Media Type");
+
+    stats.shutdown();
+}


### PR DESCRIPTION
Add support for HTTP 405 responses when a requested
resource exists, but does not support the requested method.

Also add additional unit tests to cover the change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/pistache/2)
<!-- Reviewable:end -->
