### PR TITLE
Add support for server startup notification

### DIFF
--- a/include/pistache/common.h
+++ b/include/pistache/common.h
@@ -62,6 +62,7 @@ namespace Const {
     static constexpr size_t MaxEvents  = 1024;
     static constexpr size_t MaxBuffer  = 4096;
     static constexpr size_t DefaultWorkers = 1;
+    static constexpr size_t MaxServeStartTime = 5;
 
     // Defined from CMakeLists.txt in project root
     static constexpr size_t DefaultMaxPayload = 4096;

--- a/include/pistache/endpoint.h
+++ b/include/pistache/endpoint.h
@@ -10,6 +10,8 @@
 #include <pistache/net.h>
 #include <pistache/http.h>
 
+#include <future>
+
 namespace Pistache {
 namespace Http {
 
@@ -47,6 +49,9 @@ public:
     void serve();
     void serveThreaded();
 
+    void serve(std::promise<void>& promise);
+    void serveThreaded(std::promise<void>& promise);
+
     void shutdown();
 
     bool isBound() const {
@@ -63,17 +68,17 @@ public:
 
 private:
 
-    template<typename Method>
-    void serveImpl(Method method)
+    template<typename Method, typename Argument>
+    void serveImpl(Method method, Argument& argument)
     {
-#define CALL_MEMBER_FN(obj, pmf)  ((obj).*(pmf))
+#define CALL_MEMBER_FN(obj, pmf,arg)  (((obj).*(pmf))(arg))
         if (!handler_)
             throw std::runtime_error("Must call setHandler() prior to serve()");
 
         listener.setHandler(handler_);
         listener.bind();
 
-        CALL_MEMBER_FN(listener, method)();
+        CALL_MEMBER_FN(listener, method, argument);
 #undef CALL_MEMBER_FN
     }
 

--- a/include/pistache/listener.h
+++ b/include/pistache/listener.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include <memory>
 #include <thread>
+#include <future>
 
 #include <sys/resource.h>
 
@@ -55,8 +56,8 @@ public:
     bool isBound() const;
     Port getPort() const;
 
-    void run();
-    void runThreaded();
+    void run(std::promise<void>& promise);
+    void runThreaded(std::promise<void>& promise);
 
     void shutdown();
 
@@ -67,8 +68,8 @@ public:
 
     void pinWorker(size_t worker, const CpuSet& set);
 
-private: 
-    Address addr_; 
+private:
+    Address addr_;
     int listen_fd;
     int backlog_;
     NotifyFd shutdownFd;

--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -235,9 +235,11 @@ Listener::getPort() const {
 }
 
 void
-Listener::run() {
+Listener::run(std::promise<void>& promise) {
     shutdownFd.bind(poller);
     reactor_.run();
+
+    promise.set_value();
 
     for (;;) {
         std::vector<Polling::Event> events;
@@ -271,8 +273,8 @@ Listener::run() {
 }
 
 void
-Listener::runThreaded() {
-    acceptThread = std::thread([=]() { this->run(); });
+Listener::runThreaded(std::promise<void>& promise) {
+    acceptThread = std::thread([=, &promise]() { this->run(promise); });
 }
 
 void


### PR DESCRIPTION
Add support (via std::promise and std::future) such that
`Endpoint::serve()` and `Endpoint::serveThreaded()` will allow caller to
block until server has actually started.

`serveThreaded()` will block for up to 5 seconds waiting for server to
start up. Optionally, user can pass a std::promise object and implement
their own wait.

`serve()` can be passed a std::promise object and user can implement
their own wait.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/pistache/3)
<!-- Reviewable:end -->
